### PR TITLE
Add fixture 'gruft/pixel-tube'

### DIFF
--- a/fixtures/gruft/pixel-tube.json
+++ b/fixtures/gruft/pixel-tube.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Pixel Tube",
+  "categories": ["Pixel Bar", "Color Changer"],
+  "meta": {
+    "authors": ["Flo Edelmann"],
+    "createDate": "2018-09-24",
+    "lastModifyDate": "2018-09-24"
+  },
+  "links": {
+    "productPage": [
+      "https://github.com/FloEdelmann/Esp32PixelTubes"
+    ]
+  },
+  "physical": {
+    "dimensions": [1000, 30, 40],
+    "power": 10,
+    "bulb": {
+      "type": "30x WS2812B RGB LEDs"
+    },
+    "focus": {
+      "type": "Fixed"
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Color Temperature": {
+      "capability": {
+        "type": "ColorTemperature",
+        "colorTemperatureStart": "cold",
+        "colorTemperatureEnd": "warm"
+      }
+    },
+    "Color Macros": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [11, 255],
+          "type": "ColorPreset",
+          "comment": "Color Macros"
+        }
+      ]
+    },
+    "Auto Programs": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [11, 255],
+          "type": "Effect",
+          "effectName": "Auto programs"
+        }
+      ]
+    },
+    "RGB / HSV selection": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 127],
+          "type": "Maintenance",
+          "comment": "RGB"
+        },
+        {
+          "dmxRange": [128, 255],
+          "type": "Maintenance",
+          "comment": "HSV"
+        }
+      ]
+    },
+    "Intensity $pixelKey": {
+      "defaultValue": 255,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red $pixelKey": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green $pixelKey": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue $pixelKey": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Pixel",
+      "channels": [
+        "Dimmer",
+        "Color Temperature",
+        "Color Macros",
+        "Auto Programs",
+        "RGB / HSV selection",
+        "Intensity $pixelKey",
+        "Red $pixelKey",
+        "Green $pixelKey",
+        "Blue $pixelKey"
+      ]
+    }
+  ]
+}

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -1,5 +1,10 @@
 {
   "filesystem": {
+    "gruft/pixel-tube": {
+      "name": "Pixel Tube",
+      "lastActionDate": "2018-09-24",
+      "lastAction": "created"
+    },
     "martin/atomic-3000-with-atomic-colours": {
       "name": "Atomic 3000 with Atomic Colours",
       "lastModifyDate": "2018-08-08",
@@ -7,18 +12,30 @@
     }
   },
   "manufacturers": {
+    "gruft": [
+      "pixel-tube"
+    ],
     "martin": [
       "atomic-3000-with-atomic-colours"
     ]
   },
   "categories": {
+    "Color Changer": [
+      "gruft/pixel-tube"
+    ],
     "Other": [
       "martin/atomic-3000-with-atomic-colours"
+    ],
+    "Pixel Bar": [
+      "gruft/pixel-tube"
     ]
   },
   "contributors": {
     "Anonymous": [
       "martin/atomic-3000-with-atomic-colours"
+    ],
+    "Flo Edelmann": [
+      "gruft/pixel-tube"
     ]
   },
   "rdm": {
@@ -28,6 +45,6 @@
     }
   },
   "lastUpdated": [
-    "martin/atomic-3000-with-atomic-colours"
+    "gruft/pixel-tube"
   ]
 }


### PR DESCRIPTION
* Add fixture 'gruft/pixel-tube'
* Update register.json

### Fixture warnings / errors

* gruft/pixel-tube
  - :x: File does not match schema. [ { keyword: 'pattern',
    dataPath: '.availableChannels',
    schemaPath: '#/properties/availableChannels/propertyNames/pattern',
    params: { pattern: '^[^$\n]+$' },
    message: 'should match pattern "^[^$\n]+$"',
    propertyName: 'Intensity $pixelKey' },
  { keyword: 'propertyNames',
    dataPath: '.availableChannels',
    schemaPath: '#/properties/availableChannels/propertyNames',
    params: { propertyName: 'Intensity $pixelKey' },
    message: 'property name \'Intensity $pixelKey\' is invalid' } ]


Thank you @FloEdelmann!