### PR TITLE
Add fixture 'abstract/a'

### DIFF
--- a/fixtures/abstract/a.json
+++ b/fixtures/abstract/a.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "A",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Felix Edelmann"],
+    "createDate": "2019-04-24",
+    "lastModifyDate": "2019-04-24"
+  },
+  "links": {
+    "manual": [
+      "http://localhost:5000/fixture-editor"
+    ]
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "1",
+      "channels": [
+        "Red"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'abstract/a'

### Fixture warnings / errors

* abstract/a
  - :x: Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.


Thank you @Fxedel!