### PR TITLE
Add fixture 'afx/spot-180-led'

### DIFF
--- a/fixtures/afx/spot-180-led.json
+++ b/fixtures/afx/spot-180-led.json
@@ -1,0 +1,603 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Spot 180 LED",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Aurelien", "Felix Edelmann"],
+    "createDate": "2020-03-26",
+    "lastModifyDate": "2020-03-26",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2020-03-26",
+      "comment": "created by Q Light Controller Plus (version 4.12.3 GIT)"
+    }
+  },
+  "physical": {
+    "dimensions": [470, 270, 270],
+    "weight": 11.5,
+    "power": 250,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED 180W",
+      "lumens": 60000
+    },
+    "lens": {
+      "name": "Other",
+      "degreesMinMax": [15, 15]
+    }
+  },
+  "wheels": {
+    "Colour Wheel": {
+      "slots": [
+        {
+          "type": "Color",
+          "name": "White",
+          "colors": ["#ffffff"]
+        },
+        {
+          "type": "Color",
+          "name": "Red",
+          "colors": ["#ff0000"]
+        },
+        {
+          "type": "Color",
+          "name": "Green",
+          "colors": ["#00ff00"]
+        },
+        {
+          "type": "Color",
+          "name": "Yellow",
+          "colors": ["#ffff00"]
+        },
+        {
+          "type": "Color",
+          "name": "Blue",
+          "colors": ["#0000ff"]
+        },
+        {
+          "type": "Color",
+          "name": "Pink",
+          "colors": ["#ff007f"]
+        },
+        {
+          "type": "Color",
+          "name": "Orange",
+          "colors": ["#ffaa00"]
+        },
+        {
+          "type": "Color",
+          "name": "Turquoise",
+          "colors": ["#00aaff"]
+        }
+      ]
+    },
+    "Static Gobos": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 1"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 2"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 3"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 4"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 5"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 6"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 7"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 8"
+        },
+        {
+          "type": "Open"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "fineChannelAliases": ["Pan fine"],
+      "defaultValue": 0,
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt": {
+      "fineChannelAliases": ["Tilt fine"],
+      "defaultValue": 0,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "270deg"
+      }
+    },
+    "Pan/Tilt speed": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open",
+          "comment": "Open"
+        },
+        {
+          "dmxRange": [8, 250],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "comment": "Strobe from slow to fast"
+        },
+        {
+          "dmxRange": [251, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open",
+          "comment": "Open"
+        }
+      ]
+    },
+    "Colour Wheel": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "WheelSlot",
+          "slotNumber": 1,
+          "comment": "White"
+        },
+        {
+          "dmxRange": [16, 31],
+          "type": "WheelSlot",
+          "slotNumber": 2,
+          "comment": "Red"
+        },
+        {
+          "dmxRange": [32, 47],
+          "type": "WheelSlot",
+          "slotNumber": 3,
+          "comment": "Green"
+        },
+        {
+          "dmxRange": [48, 63],
+          "type": "WheelSlot",
+          "slotNumber": 4,
+          "comment": "Yellow"
+        },
+        {
+          "dmxRange": [64, 79],
+          "type": "WheelSlot",
+          "slotNumber": 5,
+          "comment": "Blue"
+        },
+        {
+          "dmxRange": [80, 95],
+          "type": "WheelSlot",
+          "slotNumber": 6,
+          "comment": "Pink"
+        },
+        {
+          "dmxRange": [96, 111],
+          "type": "WheelSlot",
+          "slotNumber": 7,
+          "comment": "Orange"
+        },
+        {
+          "dmxRange": [112, 127],
+          "type": "WheelSlot",
+          "slotNumber": 8,
+          "comment": "Turquoise"
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "WheelSlot",
+          "slotNumber": 9,
+          "comment": "CW from slow to fast"
+        },
+        {
+          "dmxRange": [192, 255],
+          "type": "WheelSlot",
+          "slotNumber": 10,
+          "comment": "CCW from slow to fast"
+        }
+      ]
+    },
+    "Static Gobos": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 6],
+          "type": "WheelSlot",
+          "slotNumber": 1,
+          "comment": "Open"
+        },
+        {
+          "dmxRange": [7, 13],
+          "type": "WheelSlot",
+          "slotNumber": 2,
+          "comment": "Gobo 1"
+        },
+        {
+          "dmxRange": [14, 20],
+          "type": "WheelSlot",
+          "slotNumber": 3,
+          "comment": "Gobo 2"
+        },
+        {
+          "dmxRange": [21, 27],
+          "type": "WheelSlot",
+          "slotNumber": 4,
+          "comment": "Gobo 3"
+        },
+        {
+          "dmxRange": [28, 34],
+          "type": "WheelSlot",
+          "slotNumber": 5,
+          "comment": "Gobo 4"
+        },
+        {
+          "dmxRange": [35, 41],
+          "type": "WheelSlot",
+          "slotNumber": 6,
+          "comment": "Gobo 5"
+        },
+        {
+          "dmxRange": [42, 48],
+          "type": "WheelSlot",
+          "slotNumber": 7,
+          "comment": "Gobo 6"
+        },
+        {
+          "dmxRange": [49, 55],
+          "type": "WheelSlot",
+          "slotNumber": 8,
+          "comment": "Gobo 7"
+        },
+        {
+          "dmxRange": [56, 63],
+          "type": "WheelSlot",
+          "slotNumber": 9,
+          "comment": "Gobo 8"
+        },
+        {
+          "dmxRange": [64, 70],
+          "type": "WheelShake",
+          "slotNumber": 10,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "comment": "Gobo 8 Shake speed from slow to fast"
+        },
+        {
+          "dmxRange": [71, 77],
+          "type": "WheelShake",
+          "slotNumber": 11,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "comment": "Gobo 7 Shake speed from slow to fast"
+        },
+        {
+          "dmxRange": [78, 84],
+          "type": "WheelShake",
+          "slotNumber": 12,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "comment": "Gobo 6 Shake speed from slow to fast"
+        },
+        {
+          "dmxRange": [85, 91],
+          "type": "WheelShake",
+          "slotNumber": 13,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "comment": "Gobo 5 Shake speed from slow to fast"
+        },
+        {
+          "dmxRange": [92, 98],
+          "type": "WheelShake",
+          "slotNumber": 14,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "comment": "Gobo 4 Shake speed from slow to fast"
+        },
+        {
+          "dmxRange": [99, 105],
+          "type": "WheelShake",
+          "slotNumber": 15,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "comment": "Gobo 3 Shake speed from slow to fast"
+        },
+        {
+          "dmxRange": [106, 112],
+          "type": "WheelShake",
+          "slotNumber": 16,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "comment": "Gobo 2 Shake speed from slow to fast"
+        },
+        {
+          "dmxRange": [113, 119],
+          "type": "WheelShake",
+          "slotNumber": 17,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "comment": "Gobo 1 Shake speed from slow to fast"
+        },
+        {
+          "dmxRange": [120, 127],
+          "type": "WheelSlot",
+          "slotNumber": 18,
+          "comment": "Open"
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW",
+          "comment": "Gobo Rotate"
+        },
+        {
+          "dmxRange": [192, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW",
+          "comment": "Gobo Rotate"
+        }
+      ]
+    },
+    "Rotation Gobos": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "WheelSlot",
+          "slotNumber": 1,
+          "comment": "Open"
+        },
+        {
+          "dmxRange": [16, 31],
+          "type": "WheelSlot",
+          "slotNumber": 2,
+          "comment": "Gobo 1"
+        },
+        {
+          "dmxRange": [32, 47],
+          "type": "WheelSlot",
+          "slotNumber": 3,
+          "comment": "Gobo 2"
+        },
+        {
+          "dmxRange": [48, 63],
+          "type": "WheelSlot",
+          "slotNumber": 4,
+          "comment": "Gobo 3"
+        },
+        {
+          "dmxRange": [64, 79],
+          "type": "WheelSlot",
+          "slotNumber": 5,
+          "comment": "Gobo 4"
+        },
+        {
+          "dmxRange": [80, 95],
+          "type": "WheelSlot",
+          "slotNumber": 6,
+          "comment": "Gobo 5"
+        },
+        {
+          "dmxRange": [96, 127],
+          "type": "WheelSlot",
+          "slotNumber": 7,
+          "comment": "Gobo 6"
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "WheelSlotRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW",
+          "comment": "Gobo Rotate"
+        },
+        {
+          "dmxRange": [192, 255],
+          "type": "WheelSlotRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW",
+          "comment": "Gobo Rotate"
+        }
+      ]
+    },
+    "Gobo Rotation": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "WheelSlot",
+          "slotNumber": 1,
+          "comment": "Open"
+        },
+        {
+          "dmxRange": [16, 95],
+          "type": "WheelSlot",
+          "slotNumber": 2,
+          "comment": "Gobo Fine 0-360"
+        },
+        {
+          "dmxRange": [96, 135],
+          "type": "WheelSlot",
+          "slotNumber": 3,
+          "comment": "Gobo Rotating 0-90"
+        },
+        {
+          "dmxRange": [136, 155],
+          "type": "WheelSlot",
+          "slotNumber": 4,
+          "comment": "Gobo Rotating 0-180"
+        },
+        {
+          "dmxRange": [156, 175],
+          "type": "WheelSlot",
+          "slotNumber": 5,
+          "comment": "Gobo Rotating 0-720"
+        },
+        {
+          "dmxRange": [176, 215],
+          "type": "WheelSlotRotation",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "comment": "Gobo self-rotating CW from"
+        },
+        {
+          "dmxRange": [216, 255],
+          "type": "WheelSlotRotation",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "comment": "Gobo self-rotating CCW rotating from"
+        }
+      ]
+    },
+    "Focus": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Focus",
+        "distanceStart": "near",
+        "distanceEnd": "far"
+      }
+    },
+    "Prism": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 63],
+          "type": "NoFunction",
+          "comment": "Open"
+        },
+        {
+          "dmxRange": [64, 255],
+          "type": "Prism",
+          "comment": "3-facet Prism In"
+        }
+      ]
+    },
+    "Prism Rotation": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "PrismRotation",
+          "speed": "stop",
+          "comment": "Stop"
+        },
+        {
+          "dmxRange": [16, 135],
+          "type": "PrismRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW",
+          "comment": "Rotate CW slow > fast"
+        },
+        {
+          "dmxRange": [136, 255],
+          "type": "PrismRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW",
+          "comment": "Rotate CCW slow > fast"
+        }
+      ]
+    },
+    "Self-setting Program": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "Effect",
+          "effectName": "No action"
+        },
+        {
+          "dmxRange": [8, 131],
+          "type": "Effect",
+          "effectName": "Auto mode"
+        },
+        {
+          "dmxRange": [132, 255],
+          "type": "Effect",
+          "effectName": "Sound Mode",
+          "soundControlled": true
+        }
+      ]
+    },
+    "Reset": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 249],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [250, 253],
+          "type": "Maintenance"
+        },
+        {
+          "dmxRange": [254, 255],
+          "type": "NoFunction"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "16 channels",
+      "channels": [
+        "Pan",
+        "Pan fine",
+        "Tilt",
+        "Tilt fine",
+        "Pan/Tilt speed",
+        "Dimmer",
+        "Strobe",
+        "Colour Wheel",
+        "Static Gobos",
+        "Rotation Gobos",
+        "Gobo Rotation",
+        "Focus",
+        "Prism",
+        "Prism Rotation",
+        "Self-setting Program",
+        "Reset"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'afx/spot-180-led'

### Fixture warnings / errors

* afx/spot-180-led
  - :x: File does not match schema. [
  {
    keyword: 'pattern',
    dataPath: ".availableChannels['Gobo Rotation'].capabilities[5].speedStart",
    schemaPath: '#/properties/availableChannels/additionalProperties/properties/capabilities/items/allOf/0/allOf/15/then/properties/speedStart/oneOf/0/pattern',
    params: { pattern: '^-?[0-9]+(\\.[0-9]+)?Hz$' },
    message: 'should match pattern "^-?[0-9]+(\\.[0-9]+)?Hz$"'
  },
  {
    keyword: 'pattern',
    dataPath: ".availableChannels['Gobo Rotation'].capabilities[5].speedStart",
    schemaPath: '#/properties/availableChannels/additionalProperties/properties/capabilities/items/allOf/0/allOf/15/then/properties/speedStart/oneOf/1/pattern',
    params: { pattern: '^-?[0-9]+(\\.[0-9]+)?rpm$' },
    message: 'should match pattern "^-?[0-9]+(\\.[0-9]+)?rpm$"'
  },
  {
    keyword: 'pattern',
    dataPath: ".availableChannels['Gobo Rotation'].capabilities[5].speedStart",
    schemaPath: '#/properties/availableChannels/additionalProperties/properties/capabilities/items/allOf/0/allOf/15/then/properties/speedStart/oneOf/2/pattern',
    params: { pattern: '^-?[0-9]+(\\.[0-9]+)?%$' },
    message: 'should match pattern "^-?[0-9]+(\\.[0-9]+)?%$"'
  },
  {
    keyword: 'enum',
    dataPath: ".availableChannels['Gobo Rotation'].capabilities[5].speedStart",
    schemaPath: '#/properties/availableChannels/additionalProperties/properties/capabilities/items/allOf/0/allOf/15/then/properties/speedStart/oneOf/3/enum',
    params: {
      allowedValues: [
        'fast CW',
        'slow CW',
        'stop',
        'slow CCW',
        'fast CCW',
        [length]: 5
      ]
    },
    message: 'should be equal to one of the allowed values'
  },
  {
    keyword: 'oneOf',
    dataPath: ".availableChannels['Gobo Rotation'].capabilities[5].speedStart",
    schemaPath: '#/properties/availableChannels/additionalProperties/properties/capabilities/items/allOf/0/allOf/15/then/properties/speedStart/oneOf',
    params: { passingSchemas: null },
    message: 'should match exactly one schema in oneOf'
  },
  [length]: 5
]
  - :warning: Please check if manufacturer is correct.


Thank you **Aurelien**!